### PR TITLE
added swift 4.1 support

### DIFF
--- a/CommandLineKit/CommandLine.swift
+++ b/CommandLineKit/CommandLine.swift
@@ -124,7 +124,7 @@ public class CommandLine {
    */
   public var maxFlagDescriptionWidth: Int {
     if _maxFlagDescriptionWidth == 0 {
-      _maxFlagDescriptionWidth = _options.map { $0.flagDescription.characters.count }.sorted().first ?? 0
+      _maxFlagDescriptionWidth = _options.map { $0.flagDescription.count }.sorted().first ?? 0
     }
 
     return _maxFlagDescriptionWidth
@@ -301,7 +301,7 @@ public class CommandLine {
       }
 
       let skipChars = arg.hasPrefix(longOptionPrefix) ?
-        longOptionPrefix.characters.count : shortOptionPrefix.characters.count
+        longOptionPrefix.count : shortOptionPrefix.count
       let flagWithArg = arg[arg.index(arg.startIndex, offsetBy: skipChars)..<arg.endIndex]
 
       /* The argument contained nothing but ShortOptionPrefix or LongOptionPrefix */
@@ -338,9 +338,9 @@ public class CommandLine {
       }
 
       /* Flags that do not take any arguments can be concatenated */
-      let flagLength = flag.characters.count
+      let flagLength = flag.count
       if !flagMatched && !arg.hasPrefix(longOptionPrefix) {
-        let flagCharactersEnumerator = flag.characters.enumerated()
+        let flagCharactersEnumerator = flag.enumerated()
         for (i, c) in flagCharactersEnumerator {
           for option in _options where option.flagMatch(String(c)) {
             /* Values are allowed at the end of the concatenated flags, e.g.

--- a/CommandLineKit/Option.swift
+++ b/CommandLineKit/Option.swift
@@ -46,7 +46,7 @@ public class Option {
 
   internal init(_ shortFlag: String?, _ longFlag: String?, _ required: Bool, _ helpMessage: String) {
     if let sf = shortFlag {
-      assert(sf.characters.count == 1, "Short flag must be a single character")
+      assert(sf.count == 1, "Short flag must be a single character")
       assert(Int(sf) == nil && sf.toDouble() == nil, "Short flag cannot be a numeric value")
     }
 

--- a/CommandLineKit/StringExtensions.swift
+++ b/CommandLineKit/StringExtensions.swift
@@ -59,7 +59,7 @@ internal extension String {
     var numSplits = 0
 
     var curIdx = self.startIndex
-    for i in self.characters.indices {
+    for i in self.indices {
       let c = self[i]
       if c == by && (maxSplits == 0 || numSplits < maxSplits) {
 #if swift(>=3.2)
@@ -93,7 +93,7 @@ internal extension String {
    */
   func padded(toWidth width: Int, with padChar: Character = " ") -> String {
     var s = self
-    var currentLength = self.characters.count
+    var currentLength = self.count
 
     while currentLength < width {
       s.append(padChar)
@@ -121,7 +121,7 @@ internal extension String {
     var currentLineWidth = 0
 
     for word in self.split(by: splitBy) {
-      let wordLength = word.characters.count
+      let wordLength = word.count
 
       if currentLineWidth + wordLength + 1 > width {
         /* Word length is greater than line length, can't wrap */


### PR DESCRIPTION
removed all the references to "characters" and instead directly used String.